### PR TITLE
Harden v2.1.3 SSE tail buffer for Unicode chunk boundaries

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -29,6 +29,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
+const { StringDecoder } = require('string_decoder');
 
 // ─── Defaults ───────────────────────────────────────────────────────────────
 const DEFAULT_PORT = 18801;
@@ -700,16 +701,27 @@ function startServer(config) {
         if (upRes.headers['content-type'] && upRes.headers['content-type'].includes('text/event-stream')) {
           res.writeHead(status, upRes.headers);
           const TAIL_SIZE = 64;
+          // StringDecoder buffers incomplete UTF-8 sequences across TCP chunks.
+          // chunk.toString() would emit U+FFFD whenever a multi-byte char (中文,
+          // emoji, etc.) lands on a chunk boundary.
+          const decoder = new StringDecoder('utf8');
           let pending = '';
           upRes.on('data', (chunk) => {
-            pending += chunk.toString();
+            pending += decoder.write(chunk);
             if (pending.length > TAIL_SIZE) {
-              const flushable = pending.slice(0, pending.length - TAIL_SIZE);
-              pending = pending.slice(pending.length - TAIL_SIZE);
+              let sliceIdx = pending.length - TAIL_SIZE;
+              // Don't cut between a UTF-16 surrogate pair (4-byte UTF-8 chars
+              // like emoji), or flushable would end with a lone high surrogate
+              // that the downstream client can't recombine.
+              const prev = pending.charCodeAt(sliceIdx - 1);
+              if (prev >= 0xD800 && prev <= 0xDBFF) sliceIdx -= 1;
+              const flushable = pending.slice(0, sliceIdx);
+              pending = pending.slice(sliceIdx);
               res.write(reverseMap(flushable, config));
             }
           });
           upRes.on('end', () => {
+            pending += decoder.end();
             if (pending.length > 0) {
               res.write(reverseMap(pending, config));
             }


### PR DESCRIPTION
## Context — what's already done by v2.1.3

The original scope of this PR (reverse-map keywords like `ocplatform` being silently dropped when split across SSE/TCP chunks) has **already been fixed by 789f823cac7f24546796ad96862e53b7fb538385** ("v2.1.3: Tail-buffer SSE reverse mapping for chunk boundary splits"). The 64-byte tail buffer in that commit fully covers the ASCII case this PR originally addressed, so **no further work is needed for the original bug** — this PR has been rebased onto v2.1.3 and now only contains the Unicode-edge fixes that v2.1.3 leaves open.

## What this PR now does

v2.1.3's tail buffer is correct for ASCII but has two Unicode edge cases that still corrupt downstream output:

### 1. Multi-byte UTF-8 chars split across TCP chunks

`chunk.toString()` decodes each TCP chunk independently. When a 中文 / emoji / any multi-byte UTF-8 char straddles a chunk boundary, the partial bytes on each side decode to `U+FFFD` (replacement character), so the client receives mojibake instead of the original text.

**Fix:** swap `chunk.toString()` for `StringDecoder('utf8').write(chunk)`. `StringDecoder` (a Node built-in) buffers any incomplete byte sequence at the end of one write and prepends it to the next, so multi-byte chars survive arbitrary chunk boundaries. `decoder.end()` is called on stream end to flush any final remainder.

### 2. UTF-16 surrogate pair split inside the tail buffer

`pending.slice(0, pending.length - TAIL_SIZE)` operates on UTF-16 code units. A 4-byte UTF-8 char (e.g. emoji 😀, U+1F600) is one Unicode codepoint but two UTF-16 code units — a high surrogate (0xD800–0xDBFF) followed by a low surrogate (0xDC00–0xDFFF). If `pending.length - TAIL_SIZE` happens to land between the two halves, `flushable` ends with a lone high surrogate and the next write starts with a lone low surrogate. Downstream clients can't recombine them.

**Fix:** before slicing, check whether the char immediately before the slice point is a high surrogate; if so, back the slice index off by 1 so the entire surrogate pair stays in the tail buffer until the next chunk arrives.

## Diff size

15 lines added, 3 removed in `proxy.js`. No new dependencies (`string_decoder` is a Node built-in).

## Why bother — isn't this rare?

The ASCII bug v2.1.3 fixes is also rare (depends on TCP segmentation), but it bricked production sessions with permanent ENOENT loops. The Unicode variants have the same flavor: they only trigger when a chunk boundary lands inside a particular byte sequence, but when they do they produce silent corruption (`U+FFFD` or broken surrogates) that's impossible to recover from once it's in conversation history. The fix is small enough that closing the gap seems worth it.

## Test plan

- [x] `node -c proxy.js` (syntax check)
- [x] Running locally on real Claude Opus 4.6 traffic since deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)