### PR TITLE
Security hardening: credential permissions, input validation, error sanitization

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -88,7 +88,13 @@ function loadConfig() {
   let port = DEFAULT_PORT;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--port' && args[i + 1]) port = parseInt(args[i + 1]);
+    if (args[i] === '--port' && args[i + 1]) {
+      port = parseInt(args[i + 1], 10);
+      if (isNaN(port) || port < 1 || port > 65535) {
+        console.error('[ERROR] Invalid port: ' + args[i + 1] + '. Must be 1-65535.');
+        process.exit(1);
+      }
+    }
     if (args[i] === '--config' && args[i + 1]) configPath = args[i + 1];
   }
 
@@ -118,11 +124,11 @@ function loadConfig() {
 
   // macOS Keychain fallback: extract token and write to file
   if (!credsPath && process.platform === 'darwin') {
-    const { execSync } = require('child_process');
+    const { execFileSync } = require('child_process');
     const keychainNames = ['claude-code', 'claude', 'com.anthropic.claude-code'];
     for (const svc of keychainNames) {
       try {
-        const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
+        const token = execFileSync('security', ['find-generic-password', '-s', svc, '-w'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
         if (token) {
           let creds;
           try { creds = JSON.parse(token); } catch(e) {
@@ -132,8 +138,8 @@ function loadConfig() {
           }
           if (creds && creds.claudeAiOauth) {
             credsPath = path.join(homeDir, '.claude', '.credentials.json');
-            fs.mkdirSync(path.join(homeDir, '.claude'), { recursive: true });
-            fs.writeFileSync(credsPath, JSON.stringify(creds));
+            fs.mkdirSync(path.join(homeDir, '.claude'), { recursive: true, mode: 0o700 });
+            fs.writeFileSync(credsPath, JSON.stringify(creds), { mode: 0o600 });
             console.log('[PROXY] Extracted credentials from macOS Keychain to ' + credsPath);
             break;
           }
@@ -174,37 +180,32 @@ function getToken(credsPath) {
 }
 
 // ─── Request Processing ─────────────────────────────────────────────────────
-function processBody(bodyStr, config) {
-  let modified = bodyStr;
+const BILLING_OBJ = JSON.parse(BILLING_BLOCK);
 
+function processBody(bodyStr, config) {
   // 1. Apply sanitization -- raw string replacement preserves original JSON formatting
+  let modified = bodyStr;
   for (const [find, replace] of config.replacements) {
     modified = modified.split(find).join(replace);
   }
 
-  // 2. Inject billing block into system prompt
-  const sysArrayIdx = modified.indexOf('"system":[');
-  if (sysArrayIdx !== -1) {
-    const insertAt = sysArrayIdx + '"system":['.length;
-    modified = modified.slice(0, insertAt) + BILLING_BLOCK + ',' + modified.slice(insertAt);
-  } else if (modified.includes('"system":"')) {
-    const sysStart = modified.indexOf('"system":"');
-    let i = sysStart + '"system":"'.length;
-    while (i < modified.length) {
-      if (modified[i] === '\\') { i += 2; continue; }
-      if (modified[i] === '"') break;
-      i++;
-    }
-    const sysEnd = i + 1;
-    const originalSysStr = modified.slice(sysStart + '"system":'.length, sysEnd);
-    modified = modified.slice(0, sysStart)
-      + '"system":[' + BILLING_BLOCK + ',{"type":"text","text":' + originalSysStr + '}]'
-      + modified.slice(sysEnd);
-  } else {
-    modified = '{"system":[' + BILLING_BLOCK + '],' + modified.slice(1);
-  }
+  // 2. Inject billing block into system prompt using proper JSON parsing
+  try {
+    const parsed = JSON.parse(modified);
 
-  return modified;
+    if (Array.isArray(parsed.system)) {
+      parsed.system.unshift(BILLING_OBJ);
+    } else if (typeof parsed.system === 'string') {
+      parsed.system = [BILLING_OBJ, { type: 'text', text: parsed.system }];
+    } else {
+      parsed.system = [BILLING_OBJ];
+    }
+
+    return JSON.stringify(parsed);
+  } catch (e) {
+    // Fallback: if body isn't valid JSON, return sanitized string as-is
+    return modified;
+  }
 }
 
 // ─── Response Processing ────────────────────────────────────────────────────
@@ -217,6 +218,8 @@ function reverseMap(text, config) {
 }
 
 // ─── Server ─────────────────────────────────────────────────────────────────
+const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
+
 function startServer(config) {
   let requestCount = 0;
   const startedAt = Date.now();
@@ -238,8 +241,9 @@ function startServer(config) {
           reverseMapPatterns: config.reverseMap.length
         }));
       } catch (e) {
+        console.error('[PROXY] Health check error:', e.message);
         res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'error', message: e.message }));
+        res.end(JSON.stringify({ status: 'error', message: 'Internal server error' }));
       }
       return;
     }
@@ -247,17 +251,29 @@ function startServer(config) {
     requestCount++;
     const reqNum = requestCount;
     const chunks = [];
+    let bodySize = 0;
 
-    req.on('data', c => chunks.push(c));
+    req.on('data', (c) => {
+      bodySize += c.length;
+      if (bodySize > MAX_BODY_SIZE) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ type: 'error', error: { message: 'Request body too large' } }));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
     req.on('end', () => {
+      if (bodySize > MAX_BODY_SIZE) return;
       let body = Buffer.concat(chunks);
 
       let oauth;
       try {
         oauth = getToken(config.credsPath);
       } catch (e) {
+        console.error(`[${new Date().toISOString().substring(11, 19)}] #${reqNum} Token error: ${e.message}`);
         res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ type: 'error', error: { message: e.message } }));
+        res.end(JSON.stringify({ type: 'error', error: { message: 'Failed to load credentials' } }));
         return;
       }
 
@@ -293,7 +309,8 @@ function startServer(config) {
 
       const upstream = https.request({
         hostname: UPSTREAM_HOST, port: 443,
-        path: req.url, method: req.method, headers
+        path: req.url, method: req.method, headers,
+        timeout: 120000
       }, (upRes) => {
         console.log(`[${ts}] #${reqNum} > ${upRes.statusCode}`);
 
@@ -320,11 +337,16 @@ function startServer(config) {
         }
       });
 
+      upstream.on('timeout', () => {
+        console.error(`[${ts}] #${reqNum} ERR: upstream timeout`);
+        upstream.destroy(new Error('upstream timeout'));
+      });
+
       upstream.on('error', (e) => {
         console.error(`[${ts}] #${reqNum} ERR: ${e.message}`);
         if (!res.headersSent) {
           res.writeHead(502, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ type: 'error', error: { message: e.message } }));
+          res.end(JSON.stringify({ type: 'error', error: { message: 'Upstream request failed' } }));
         }
       });
 

--- a/setup.js
+++ b/setup.js
@@ -47,7 +47,7 @@ for (const p of credsPaths) {
 // If no file-based credentials, try macOS Keychain
 if (!creds && process.platform === 'darwin') {
   console.log('   File credentials not found, checking macOS Keychain...');
-  const { execSync } = require('child_process');
+  const { execFileSync } = require('child_process');
 
   // Try common Keychain service names
   const keychainNames = ['claude-code', 'claude', 'com.anthropic.claude-code'];
@@ -55,7 +55,7 @@ if (!creds && process.platform === 'darwin') {
 
   for (const svc of keychainNames) {
     try {
-      keychainToken = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
+      keychainToken = execFileSync('security', ['find-generic-password', '-s', svc, '-w'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
       if (keychainToken) {
         console.log('   Found token in macOS Keychain (service: ' + svc + ')');
         break;
@@ -88,8 +88,8 @@ if (!creds && process.platform === 'darwin') {
       // Write credentials to file so the proxy can read them
       credsPath = path.join(homeDir, '.claude', '.credentials.json');
       const claudeDir = path.join(homeDir, '.claude');
-      if (!fs.existsSync(claudeDir)) { fs.mkdirSync(claudeDir, { recursive: true }); }
-      fs.writeFileSync(credsPath, JSON.stringify(creds));
+      if (!fs.existsSync(claudeDir)) { fs.mkdirSync(claudeDir, { recursive: true, mode: 0o700 }); }
+      fs.writeFileSync(credsPath, JSON.stringify(creds), { mode: 0o600 });
       console.log('   Written Keychain credentials to: ' + credsPath);
       console.log('   NOTE: You may need to re-run this after token refresh (every ~24h)');
     }
@@ -99,11 +99,11 @@ if (!creds && process.platform === 'darwin') {
 // If still no credentials, try forcing a credential write via claude CLI
 if (!creds) {
   console.log('   No credentials found. Attempting to trigger credential write...');
-  const { execSync } = require('child_process');
+  const { execFileSync: execFileSyncCli } = require('child_process');
   try {
-    execSync('claude -p "ping" --max-turns 1 --no-session-persistence --output-format json 2>/dev/null', {
+    execFileSyncCli('claude', ['-p', 'ping', '--max-turns', '1', '--no-session-persistence', '--output-format', 'json'], {
       timeout: 30000,
-      stdio: 'pipe'
+      stdio: ['pipe', 'pipe', 'ignore']
     });
     // Re-check files after the CLI call
     for (const p of credsPaths) {
@@ -327,7 +327,7 @@ const config = {
 };
 
 const configPath = path.join(process.cwd(), 'config.json');
-fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+fs.writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
 console.log('   Written: ' + configPath);
 console.log('   Sanitization patterns: ' + replacements.length);
 console.log('   Reverse map patterns: ' + reverseMap.length);

--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -74,11 +74,11 @@ for (const p of credsPaths) {
 // macOS Keychain fallback
 if (!credsPath && process.platform === 'darwin') {
   info('No credential files found. Checking macOS Keychain...');
-  const { execSync } = require('child_process');
+  const { execFileSync } = require('child_process');
   const keychainNames = ['claude-code', 'claude', 'com.anthropic.claude-code'];
   for (const svc of keychainNames) {
     try {
-      const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
+      const token = execFileSync('security', ['find-generic-password', '-s', svc, '-w'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
       if (token) {
         ok('Token found in macOS Keychain', 'service: ' + svc);
         try {
@@ -128,7 +128,7 @@ const oauth = creds.claudeAiOauth;
 const token = oauth.accessToken;
 const expiresIn = (oauth.expiresAt - Date.now()) / 3600000;
 
-ok('Token prefix', token.substring(0, 20) + '...');
+ok('Token format', token.startsWith('sk-ant-') ? 'sk-ant-* (' + token.length + ' chars)' : 'unknown format (' + token.length + ' chars)');
 ok('Subscription', oauth.subscriptionType || 'unknown');
 
 if (expiresIn > 0) {


### PR DESCRIPTION
## Summary
- Fix credential file permissions (0o600/0o700) to prevent local token theft
- Replace `execSync` with `execFileSync` to eliminate command injection patterns
- Add 10MB request body size limit and 120s upstream timeout
- Sanitize error responses to avoid leaking internal paths and token details
- Replace fragile string-based JSON manipulation with proper `JSON.parse`/`JSON.stringify`
- Validate `--port` CLI argument and reduce token prefix logging

## Test plan
- [ ] Run `node proxy.js` and verify startup with valid credentials
- [ ] Run `node proxy.js --port abc` and verify it exits with validation error
- [ ] Run `node troubleshoot.js` and verify all 8 diagnostic layers pass
- [ ] Verify credential file permissions: `ls -la ~/.claude/.credentials.json` shows `-rw-------`
- [ ] Send a test request through the proxy and verify JSON responses are well-formed
- [ ] Hit `/health` endpoint and verify no internal error details leak on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)