### PR TITLE
fix: make OpenClaw config check informational instead of a failure

### DIFF
--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -348,7 +348,7 @@ async function runTests() {
   }
 
   // ─── 9. OpenClaw Configuration Check ───────────────────────────────────────
-  console.log('\n9. Checking OpenClaw configuration...\n');
+  console.log('\n9. Checking OpenClaw configuration (optional)...\n');
 
   const ocConfigPaths = [
     path.join(os.homedir(), '.openclaw', 'openclaw.json'),
@@ -374,18 +374,13 @@ async function runTests() {
           } else if (baseUrl.includes('127.0.0.1') || baseUrl.includes('localhost')) {
             info('OpenClaw baseUrl: ' + baseUrl + ' (custom port -- make sure proxy is on that port)');
           } else {
-            fail('OpenClaw baseUrl is NOT pointing to the proxy', baseUrl);
-            info('Change models.providers.anthropic.baseUrl to "http://127.0.0.1:18801" in ' + ocPath);
-            info('Then restart the OpenClaw gateway.');
-            info('');
-            info('Note: ANTHROPIC_BASE_URL env var does NOT control OpenClaw routing.');
-            info('You must set baseUrl in openclaw.json under models.providers.anthropic.');
+            info('OpenClaw baseUrl is NOT pointing to the proxy -- ' + baseUrl);
+            info('To route through proxy, change models.providers.anthropic.baseUrl to "http://127.0.0.1:18801" in ' + ocPath);
           }
         } else {
-          fail('No baseUrl found in OpenClaw config', 'OpenClaw is using the default Anthropic API directly');
-          info('Add this to ' + ocPath + ':');
+          info('No baseUrl found in OpenClaw config -- using the default Anthropic API directly');
+          info('To route through proxy, add to ' + ocPath + ':');
           info('  "models": { "providers": { "anthropic": { "baseUrl": "http://127.0.0.1:18801" } } }');
-          info('Then restart the OpenClaw gateway.');
         }
       } catch(e) {
         info('Found ' + ocPath + ' but failed to parse: ' + e.message);


### PR DESCRIPTION
## Summary
- Changes troubleshoot.js step 9 (OpenClaw configuration check) from `[FAIL]` to `[INFO]`
- Anthropic is not always the primary/default provider — some users intentionally use the official API directly and create a new provider and model with `openclaw-billing-proxy`
- The step now provides guidance on how to route through the proxy without penalizing valid configurations

## Test plan
- [x] Run `node troubleshoot.js` without proxy baseUrl configured — should show `[INFO]` instead of `[FAIL]`
- [x] Run with proxy baseUrl configured — should still show `[PASS]`
- [x] Verify pass/fail summary count is unaffected by this step


## Logs

Before

```shell
9. Checking OpenClaw configuration...

  [FAIL] No baseUrl found in OpenClaw config -- OpenClaw is using the default Anthropic API directly
  [INFO] Add this to /Users/blogbin/.openclaw/openclaw.json:
  [INFO]   "models": { "providers": { "anthropic": { "baseUrl": "http://127.0.0.1:18801" } } }
  [INFO] Then restart the OpenClaw gateway.

---------------------------------
  Results: 9 passed, 1 failed
---------------------------------

  Fix the FAIL items above and run this script again.
```

After 

```shell
9. Checking OpenClaw configuration (optional)...

  [INFO] No baseUrl found in OpenClaw config -- using the default Anthropic API directly
  [INFO] To route through proxy, add to /Users/blogbin/.openclaw/openclaw.json:
  [INFO]   "models": { "providers": { "anthropic": { "baseUrl": "http://127.0.0.1:18801" } } }

---------------------------------
  Results: 9 passed, 0 failed
---------------------------------

  Everything looks good! If OpenClaw requests still fail,
  check the proxy console for 400 errors and add sanitization
  patterns to config.json for any trigger terms in your content.
```