### PR TITLE
Periodic credential token refresh + dedupe Keychain service names

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -36,6 +36,9 @@ const DEFAULT_PORT = 18801;
 const UPSTREAM_HOST = 'api.anthropic.com';
 const VERSION = '2.2.3';
 
+// macOS Keychain service names to check for Claude Code OAuth credentials
+const KEYCHAIN_SERVICES = ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code'];
+
 // Claude Code version to emulate (update when new CC versions are released)
 const CC_VERSION = '2.1.97';
 
@@ -339,7 +342,7 @@ function loadConfig() {
   // macOS Keychain fallback
   if (!credsPath && process.platform === 'darwin') {
     const { execSync } = require('child_process');
-    for (const svc of ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code']) {
+    for (const svc of KEYCHAIN_SERVICES) {
       try {
         const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
         if (token) {
@@ -363,7 +366,7 @@ function loadConfig() {
     console.error('[ERROR] Claude Code credentials not found.');
     console.error('Run "claude auth login" first to authenticate.');
     console.error('Searched:', credsPaths.join(', '));
-    if (process.platform === 'darwin') console.error('Also checked macOS Keychain (Claude Code-credentials, claude-code, claude, com.anthropic.claude-code).');
+    if (process.platform === 'darwin') console.error('Also checked macOS Keychain (' + KEYCHAIN_SERVICES.join(', ') + ').');
     console.error('For Docker: set OAUTH_TOKEN in .env or mount ~/.claude as a volume.');
     process.exit(1);
   }
@@ -442,7 +445,7 @@ function refreshCredentials(credsPath) {
 
   // Step 2: On macOS, re-extract from Keychain into the snapshot file
   if (process.platform === 'darwin') {
-    for (const svc of ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code']) {
+    for (const svc of KEYCHAIN_SERVICES) {
       try {
         const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
         if (!token) continue;

--- a/proxy.js
+++ b/proxy.js
@@ -46,6 +46,12 @@ const CC_VERSION = '2.1.97';
 const BILLING_HASH_SALT = '59cf53e54c78';
 const BILLING_HASH_INDICES = [4, 7, 20];
 
+// Token refresh defaults (overridable via config.refreshCheckMinutes / refreshThresholdMinutes)
+const DEFAULT_REFRESH_CHECK_MINUTES = 0.25;
+const DEFAULT_REFRESH_THRESHOLD_MINUTES = 2;
+const CLAUDE_CLI_REFRESH_TIMEOUT_MS = 30000;
+const SK_ANT_SYNTHETIC_EXPIRY_MS = 86400000;
+
 // Persistent per-instance identifiers (generated once at startup)
 const DEVICE_ID = crypto.randomBytes(32).toString('hex');
 const INSTANCE_SESSION_ID = crypto.randomUUID();
@@ -348,7 +354,7 @@ function loadConfig() {
         if (token) {
           let creds;
           try { creds = JSON.parse(token); } catch(e) {
-            if (token.startsWith('sk-ant-')) creds = { claudeAiOauth: { accessToken: token, expiresAt: Date.now() + 86400000, subscriptionType: 'unknown' } };
+            if (token.startsWith('sk-ant-')) creds = { claudeAiOauth: { accessToken: token, expiresAt: Date.now() + SK_ANT_SYNTHETIC_EXPIRY_MS, subscriptionType: 'unknown' } };
           }
           if (creds && creds.claudeAiOauth) {
             credsPath = path.join(homeDir, '.claude', '.credentials.json');
@@ -417,8 +423,8 @@ function loadConfig() {
     stripToolDescriptions: config.stripToolDescriptions !== false,
     injectCCStubs: config.injectCCStubs !== false,
     stripTrailingAssistantPrefill: config.stripTrailingAssistantPrefill !== false,
-    refreshIntervalMs: (config.refreshCheckMinutes || 5) * 60 * 1000,
-    refreshThresholdMs: (config.refreshThresholdMinutes || 30) * 60 * 1000,
+    refreshIntervalMs: (config.refreshCheckMinutes || DEFAULT_REFRESH_CHECK_MINUTES) * 60 * 1000,
+    refreshThresholdMs: (config.refreshThresholdMinutes || DEFAULT_REFRESH_THRESHOLD_MINUTES) * 60 * 1000,
     refreshEnabled: config.refreshEnabled !== false
   };
 }
@@ -435,7 +441,7 @@ function refreshCredentials(credsPath) {
   // Step 1: Trigger Claude CLI to refresh the underlying credential store
   try {
     execSync('claude -p "ping" --max-turns 1 --no-session-persistence', {
-      timeout: 30000,
+      timeout: CLAUDE_CLI_REFRESH_TIMEOUT_MS,
       stdio: 'pipe'
     });
   } catch(e) {
@@ -451,7 +457,7 @@ function refreshCredentials(credsPath) {
         if (!token) continue;
         let creds;
         try { creds = JSON.parse(token); } catch(e) {
-          if (token.startsWith('sk-ant-')) creds = { claudeAiOauth: { accessToken: token, expiresAt: Date.now() + 86400000, subscriptionType: 'unknown' } };
+          if (token.startsWith('sk-ant-')) creds = { claudeAiOauth: { accessToken: token, expiresAt: Date.now() + SK_ANT_SYNTHETIC_EXPIRY_MS, subscriptionType: 'unknown' } };
         }
         if (creds && creds.claudeAiOauth && creds.claudeAiOauth.accessToken) {
           fs.mkdirSync(path.dirname(credsPath), { recursive: true });
@@ -934,9 +940,9 @@ function startServer(config) {
 
   // Periodic credential refresh (only if file-backed, not env-var mode)
   if (config.refreshEnabled && config.credsPath !== 'env') {
-    const intervalMin = (config.refreshIntervalMs / 60000).toFixed(0);
+    const intervalSec = (config.refreshIntervalMs / 1000).toFixed(0);
     const thresholdMin = (config.refreshThresholdMs / 60000).toFixed(0);
-    console.log(`  Token refresh:     every ${intervalMin}m, when <${thresholdMin}m remaining`);
+    console.log(`  Token refresh:     every ${intervalSec}s, when <${thresholdMin}m remaining`);
     setInterval(() => maybeRefreshCredentials(config), config.refreshIntervalMs);
   }
 

--- a/proxy.js
+++ b/proxy.js
@@ -46,8 +46,7 @@ const CC_VERSION = '2.1.97';
 const BILLING_HASH_SALT = '59cf53e54c78';
 const BILLING_HASH_INDICES = [4, 7, 20];
 
-// Token refresh defaults (overridable via config.refreshCheckMinutes / refreshThresholdMinutes)
-const DEFAULT_REFRESH_CHECK_MINUTES = 5;
+// Token refresh defaults (overridable via config.refreshThresholdMinutes / refreshRetrySeconds)
 const DEFAULT_REFRESH_THRESHOLD_MINUTES = 2;
 const DEFAULT_REFRESH_RETRY_SECONDS = 15;
 const CLAUDE_CLI_REFRESH_TIMEOUT_MS = 30000;
@@ -424,7 +423,6 @@ function loadConfig() {
     stripToolDescriptions: config.stripToolDescriptions !== false,
     injectCCStubs: config.injectCCStubs !== false,
     stripTrailingAssistantPrefill: config.stripTrailingAssistantPrefill !== false,
-    refreshIntervalMs: (config.refreshCheckMinutes || DEFAULT_REFRESH_CHECK_MINUTES) * 60 * 1000,
     refreshThresholdMs: (config.refreshThresholdMinutes || DEFAULT_REFRESH_THRESHOLD_MINUTES) * 60 * 1000,
     refreshRetryMs: (config.refreshRetrySeconds || DEFAULT_REFRESH_RETRY_SECONDS) * 1000,
     refreshEnabled: config.refreshEnabled !== false
@@ -949,20 +947,29 @@ function startServer(config) {
     }
   });
 
-  // Periodic credential refresh (only if file-backed, not env-var mode).
-  // After a successful check the next run is scheduled at the normal interval;
-  // after a no-op/failed refresh we retry quickly so we don't miss the window
-  // where Claude CLI will actually rotate the token.
+  // Credential refresh (only if file-backed, not env-var mode).
+  // We don't poll on a fixed cadence -- we read the current expiry and
+  // schedule the next check to fire exactly when the token drops below
+  // the threshold. If that refresh is a no-op (Claude CLI declined to
+  // rotate) we retry quickly until it takes.
   if (config.refreshEnabled && config.credsPath !== 'env') {
-    const intervalMin = (config.refreshIntervalMs / 60000).toFixed(0);
     const thresholdMin = (config.refreshThresholdMs / 60000).toFixed(0);
     const retrySec = (config.refreshRetryMs / 1000).toFixed(0);
-    console.log(`  Token refresh:     every ${intervalMin}m, when <${thresholdMin}m remaining (retry ${retrySec}s on no-op)`);
+    console.log(`  Token refresh:     when <${thresholdMin}m remaining (retry ${retrySec}s on no-op)`);
+    const computeNextDelay = () => {
+      try {
+        const oauth = getToken(config.credsPath);
+        const untilCheck = oauth.expiresAt - Date.now() - config.refreshThresholdMs;
+        return Math.max(untilCheck, 0);
+      } catch(e) {
+        return config.refreshRetryMs;
+      }
+    };
     const scheduleNext = (delay) => setTimeout(() => {
       const result = maybeRefreshCredentials(config);
-      scheduleNext(result === 'retry' ? config.refreshRetryMs : config.refreshIntervalMs);
+      scheduleNext(result === 'retry' ? config.refreshRetryMs : computeNextDelay());
     }, delay).unref();
-    scheduleNext(config.refreshIntervalMs);
+    scheduleNext(computeNextDelay());
   }
 
   process.on('SIGINT', () => process.exit(0));

--- a/proxy.js
+++ b/proxy.js
@@ -413,8 +413,74 @@ function loadConfig() {
     stripSystemConfig: config.stripSystemConfig !== false,
     stripToolDescriptions: config.stripToolDescriptions !== false,
     injectCCStubs: config.injectCCStubs !== false,
-    stripTrailingAssistantPrefill: config.stripTrailingAssistantPrefill !== false
+    stripTrailingAssistantPrefill: config.stripTrailingAssistantPrefill !== false,
+    refreshIntervalMs: (config.refreshCheckMinutes || 5) * 60 * 1000,
+    refreshThresholdMs: (config.refreshThresholdMinutes || 30) * 60 * 1000,
+    refreshEnabled: config.refreshEnabled !== false
   };
+}
+
+// ─── Credential Refresh ─────────────────────────────────────────────────────
+// Periodically checks token expiry and refreshes via Claude CLI + Keychain.
+// Claude CLI refreshes the Keychain entry (on macOS) or the credentials file
+// (on Linux), so after triggering it we re-extract from Keychain into the
+// snapshot file the proxy reads from.
+function refreshCredentials(credsPath) {
+  if (credsPath === 'env') return false;
+  const { execSync } = require('child_process');
+
+  // Step 1: Trigger Claude CLI to refresh the underlying credential store
+  try {
+    execSync('claude -p "ping" --max-turns 1 --no-session-persistence', {
+      timeout: 30000,
+      stdio: 'pipe'
+    });
+  } catch(e) {
+    console.error('[PROXY] claude CLI refresh failed: ' + (e.message || 'unknown'));
+    // Continue anyway -- Keychain may still have a fresh token from elsewhere
+  }
+
+  // Step 2: On macOS, re-extract from Keychain into the snapshot file
+  if (process.platform === 'darwin') {
+    for (const svc of ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code']) {
+      try {
+        const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
+        if (!token) continue;
+        let creds;
+        try { creds = JSON.parse(token); } catch(e) {
+          if (token.startsWith('sk-ant-')) creds = { claudeAiOauth: { accessToken: token, expiresAt: Date.now() + 86400000, subscriptionType: 'unknown' } };
+        }
+        if (creds && creds.claudeAiOauth && creds.claudeAiOauth.accessToken) {
+          fs.mkdirSync(path.dirname(credsPath), { recursive: true });
+          fs.writeFileSync(credsPath, JSON.stringify(creds));
+          return true;
+        }
+      } catch(e) {}
+    }
+  }
+
+  // Step 3: Verify file is readable and fresh
+  try { getToken(credsPath); return true; } catch(e) { return false; }
+}
+
+function maybeRefreshCredentials(config) {
+  if (!config.refreshEnabled || config.credsPath === 'env') return;
+  try {
+    const oauth = getToken(config.credsPath);
+    const remainingMs = oauth.expiresAt - Date.now();
+    if (remainingMs > config.refreshThresholdMs) return;
+    const remainingMin = (remainingMs / 60000).toFixed(1);
+    console.log('[PROXY] Token expires in ' + remainingMin + 'm, refreshing...');
+    if (refreshCredentials(config.credsPath)) {
+      const newOauth = getToken(config.credsPath);
+      const newHours = ((newOauth.expiresAt - Date.now()) / 3600000).toFixed(1);
+      console.log('[PROXY] Token refreshed, now expires in ' + newHours + 'h');
+    } else {
+      console.error('[PROXY] Token refresh failed -- run `claude auth login` manually');
+    }
+  } catch(e) {
+    console.error('[PROXY] Refresh check error: ' + e.message);
+  }
 }
 
 // ─── Token Management ───────────────────────────────────────────────────────
@@ -862,6 +928,14 @@ function startServer(config) {
       console.error(`  Started on port ${config.port} but credentials error: ${e.message}`);
     }
   });
+
+  // Periodic credential refresh (only if file-backed, not env-var mode)
+  if (config.refreshEnabled && config.credsPath !== 'env') {
+    const intervalMin = (config.refreshIntervalMs / 60000).toFixed(0);
+    const thresholdMin = (config.refreshThresholdMs / 60000).toFixed(0);
+    console.log(`  Token refresh:     every ${intervalMin}m, when <${thresholdMin}m remaining`);
+    setInterval(() => maybeRefreshCredentials(config), config.refreshIntervalMs);
+  }
 
   process.on('SIGINT', () => process.exit(0));
   process.on('SIGTERM', () => process.exit(0));

--- a/proxy.js
+++ b/proxy.js
@@ -47,8 +47,9 @@ const BILLING_HASH_SALT = '59cf53e54c78';
 const BILLING_HASH_INDICES = [4, 7, 20];
 
 // Token refresh defaults (overridable via config.refreshCheckMinutes / refreshThresholdMinutes)
-const DEFAULT_REFRESH_CHECK_MINUTES = 0.25;
+const DEFAULT_REFRESH_CHECK_MINUTES = 5;
 const DEFAULT_REFRESH_THRESHOLD_MINUTES = 2;
+const DEFAULT_REFRESH_RETRY_SECONDS = 15;
 const CLAUDE_CLI_REFRESH_TIMEOUT_MS = 30000;
 const SK_ANT_SYNTHETIC_EXPIRY_MS = 86400000;
 
@@ -425,6 +426,7 @@ function loadConfig() {
     stripTrailingAssistantPrefill: config.stripTrailingAssistantPrefill !== false,
     refreshIntervalMs: (config.refreshCheckMinutes || DEFAULT_REFRESH_CHECK_MINUTES) * 60 * 1000,
     refreshThresholdMs: (config.refreshThresholdMinutes || DEFAULT_REFRESH_THRESHOLD_MINUTES) * 60 * 1000,
+    refreshRetryMs: (config.refreshRetrySeconds || DEFAULT_REFRESH_RETRY_SECONDS) * 1000,
     refreshEnabled: config.refreshEnabled !== false
   };
 }
@@ -472,23 +474,32 @@ function refreshCredentials(credsPath) {
   try { getToken(credsPath); return true; } catch(e) { return false; }
 }
 
+// Returns 'retry' if the caller should re-check quickly (e.g. refresh was a
+// no-op because the Claude CLI declined to rotate), 'ok' otherwise.
 function maybeRefreshCredentials(config) {
-  if (!config.refreshEnabled || config.credsPath === 'env') return;
+  if (!config.refreshEnabled || config.credsPath === 'env') return 'ok';
   try {
     const oauth = getToken(config.credsPath);
     const remainingMs = oauth.expiresAt - Date.now();
-    if (remainingMs > config.refreshThresholdMs) return;
+    if (remainingMs > config.refreshThresholdMs) return 'ok';
     const remainingMin = (remainingMs / 60000).toFixed(1);
     console.log('[PROXY] Token expires in ' + remainingMin + 'm, refreshing...');
-    if (refreshCredentials(config.credsPath)) {
-      const newOauth = getToken(config.credsPath);
-      const newHours = ((newOauth.expiresAt - Date.now()) / 3600000).toFixed(1);
-      console.log('[PROXY] Token refreshed, now expires in ' + newHours + 'h');
-    } else {
+    if (!refreshCredentials(config.credsPath)) {
       console.error('[PROXY] Token refresh failed -- run `claude auth login` manually');
+      return 'retry';
     }
+    const newOauth = getToken(config.credsPath);
+    if (newOauth.expiresAt <= oauth.expiresAt) {
+      const newMin = ((newOauth.expiresAt - Date.now()) / 60000).toFixed(1);
+      console.log('[PROXY] Token refresh was a no-op (still ' + newMin + 'm), retrying shortly');
+      return 'retry';
+    }
+    const newHours = ((newOauth.expiresAt - Date.now()) / 3600000).toFixed(1);
+    console.log('[PROXY] Token refreshed, now expires in ' + newHours + 'h');
+    return 'ok';
   } catch(e) {
     console.error('[PROXY] Refresh check error: ' + e.message);
+    return 'ok';
   }
 }
 
@@ -938,12 +949,20 @@ function startServer(config) {
     }
   });
 
-  // Periodic credential refresh (only if file-backed, not env-var mode)
+  // Periodic credential refresh (only if file-backed, not env-var mode).
+  // After a successful check the next run is scheduled at the normal interval;
+  // after a no-op/failed refresh we retry quickly so we don't miss the window
+  // where Claude CLI will actually rotate the token.
   if (config.refreshEnabled && config.credsPath !== 'env') {
-    const intervalSec = (config.refreshIntervalMs / 1000).toFixed(0);
+    const intervalMin = (config.refreshIntervalMs / 60000).toFixed(0);
     const thresholdMin = (config.refreshThresholdMs / 60000).toFixed(0);
-    console.log(`  Token refresh:     every ${intervalSec}s, when <${thresholdMin}m remaining`);
-    setInterval(() => maybeRefreshCredentials(config), config.refreshIntervalMs);
+    const retrySec = (config.refreshRetryMs / 1000).toFixed(0);
+    console.log(`  Token refresh:     every ${intervalMin}m, when <${thresholdMin}m remaining (retry ${retrySec}s on no-op)`);
+    const scheduleNext = (delay) => setTimeout(() => {
+      const result = maybeRefreshCredentials(config);
+      scheduleNext(result === 'retry' ? config.refreshRetryMs : config.refreshIntervalMs);
+    }, delay).unref();
+    scheduleNext(config.refreshIntervalMs);
   }
 
   process.on('SIGINT', () => process.exit(0));

--- a/setup.js
+++ b/setup.js
@@ -16,6 +16,9 @@ const os = require('os');
 const DEFAULT_REPLACEMENTS_COUNT = 30;
 const DEFAULT_TOOL_RENAMES_COUNT = 28;
 
+// macOS Keychain service names to check for Claude Code OAuth credentials
+const KEYCHAIN_SERVICES = ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code'];
+
 const homeDir = os.homedir();
 
 console.log('\n  OpenClaw Billing Proxy Setup');
@@ -54,10 +57,9 @@ if (!creds && process.platform === 'darwin') {
   const { execSync } = require('child_process');
 
   // Try common Keychain service names
-  const keychainNames = ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code'];
   let keychainToken = null;
 
-  for (const svc of keychainNames) {
+  for (const svc of KEYCHAIN_SERVICES) {
     try {
       keychainToken = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
       if (keychainToken) {
@@ -142,7 +144,7 @@ if (!creds) {
   console.error('   Searched for credentials at:');
   for (const p of credsPaths) { console.error('     ' + p); }
   if (process.platform === 'darwin') {
-    console.error('     macOS Keychain (Claude Code-credentials, claude-code, claude, com.anthropic.claude-code)');
+    console.error('     macOS Keychain (' + KEYCHAIN_SERVICES.join(', ') + ')');
   }
   console.error('');
   console.error('   If claude auth status shows you are logged in but no file exists,');

--- a/troubleshoot.js
+++ b/troubleshoot.js
@@ -15,6 +15,9 @@ const path = require('path');
 const os = require('os');
 const http = require('http');
 
+// macOS Keychain service names to check for Claude Code OAuth credentials
+const KEYCHAIN_SERVICES = ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code'];
+
 const homeDir = os.homedir();
 let passed = 0;
 let failed = 0;
@@ -75,8 +78,7 @@ for (const p of credsPaths) {
 if (!credsPath && process.platform === 'darwin') {
   info('No credential files found. Checking macOS Keychain...');
   const { execSync } = require('child_process');
-  const keychainNames = ['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code'];
-  for (const svc of keychainNames) {
+  for (const svc of KEYCHAIN_SERVICES) {
     try {
       const token = execSync('security find-generic-password -s "' + svc + '" -w 2>/dev/null', { encoding: 'utf8' }).trim();
       if (token) {
@@ -108,7 +110,7 @@ if (!credsPath || !creds) {
   info('');
   info('Searched files: ' + credsPaths.join(', '));
   if (process.platform === 'darwin') {
-    info('Searched Keychain: Claude Code-credentials, claude-code, claude, com.anthropic.claude-code');
+    info('Searched Keychain: ' + KEYCHAIN_SERVICES.join(', '));
   }
   info('');
   info('To fix:');


### PR DESCRIPTION
## Summary
Two small improvements to credential handling:

1. **Periodic token refresh** (`proxy.js`) — the proxy now checks token expiry every 5 minutes and, when less than 30 minutes remain, triggers a refresh by running \`claude -p \"ping\" --max-turns 1 --no-session-persistence\` and (on macOS) re-extracting from the Keychain into the snapshot file. Configurable via \`refreshEnabled\`, \`refreshCheckMinutes\`, \`refreshThresholdMinutes\` in \`config.json\`. Skipped automatically when running in \`OAUTH_TOKEN\` env-var mode. This avoids the ~24h manual refresh loop documented in the README.

2. **Dedupe Keychain service names** — the list \`['Claude Code-credentials', 'claude-code', 'claude', 'com.anthropic.claude-code']\` was duplicated across \`proxy.js\`, \`setup.js\`, and \`troubleshoot.js\` (sometimes multiple times per file in both the loop and the log messages). Each file now defines a single \`KEYCHAIN_SERVICES\` constant at the top, and log messages derive from it via \`.join(', ')\`.