### PR TITLE
v2.2.5: Protect filesystem paths from Layer 2 global string replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v2.2.5 -- 2026-04-10
+
+### Protect filesystem paths from Layer 2 global string replacement
+
+**Changes:**
+- Layer 2 `split/join` replacements now extract filesystem paths into NUL-delimited
+  placeholders before applying replacements, then restore them after. Paths with 2+
+  segments (e.g. `/home/user/.openclaw/media/...`, `./src/openclaw/mod.js`) are
+  detected by a regex with a negative lookbehind `(?<![\/:])` to skip URL schemes.
+
+**Why:**
+Layer 2 blindly replaced every occurrence of trigger strings (e.g. `openclaw` →
+`tataclaw`) across the entire request body, including inside filesystem paths in
+tool call arguments. This turned `/home/tata/.openclaw/media/...` into
+`/home/tata/.tataclaw/media/...`. OpenClaw's `assertLocalMediaAllowed()` security
+check then rejected the path because it was no longer under an allowed directory
+root.
+
+The response-side `reverseMap()` is left unchanged — its replacements are corrective
+(restoring replaced strings back to originals), so path protection is not needed there.
+
+---
+
 ## v2.2.4 -- 2026-04-09
 
 ### Fix config strip boundary using filesystem paths instead of AGENTS.md (closes #26)

--- a/proxy.js
+++ b/proxy.js
@@ -34,7 +34,7 @@ const { StringDecoder } = require('string_decoder');
 // ─── Defaults ───────────────────────────────────────────────────────────────
 const DEFAULT_PORT = 18801;
 const UPSTREAM_HOST = 'api.anthropic.com';
-const VERSION = '2.2.3';
+const VERSION = '2.2.5';
 
 // Claude Code version to emulate (update when new CC versions are released)
 const CC_VERSION = '2.1.97';
@@ -452,14 +452,46 @@ function findMatchingBracket(str, start) {
   return -1;
 }
 
+// ─── Filesystem Path Protection ─────────────────────────────────────────────
+// Matches absolute paths with 2+ segments (e.g. /home/user/.openclaw/file.png)
+// and relative paths starting with ./ or ../ (e.g. ./src/openclaw/mod.js).
+// Uses NUL byte delimiters as placeholders — safe since NUL never appears in JSON.
+const _FS_PATH_RE = /(?:\.\.?)?(?<![\/:])\/(?:[\w.~@+-]+\/)+[\w.~@+-]*/g;
+
+function protectPaths(str) {
+  const saved = [];
+  const result = str.replace(_FS_PATH_RE, (match) => {
+    saved.push(match);
+    return `\x00P${saved.length - 1}\x00`;
+  });
+  return { result, saved };
+}
+
+function restorePaths(str, saved) {
+  for (let i = 0; i < saved.length; i++) {
+    str = str.split(`\x00P${i}\x00`).join(saved[i]);
+  }
+  return str;
+}
+
 // ─── Request Processing ─────────────────────────────────────────────────────
 function processBody(bodyStr, config) {
   let m = bodyStr;
+
+  // Protect filesystem paths from Layer 2 blind string replacement.
+  // Without this, paths like /home/user/.openclaw/media/... get corrupted
+  // (e.g. .openclaw -> .tataclaw), breaking OpenClaw's assertLocalMediaAllowed()
+  // security check which validates against allowed directory roots.
+  const { result: pathProtected, saved: savedPaths } = protectPaths(m);
+  m = pathProtected;
 
   // Layer 2: String trigger sanitization (global split/join)
   for (const [find, replace] of config.replacements) {
     m = m.split(find).join(replace);
   }
+
+  // Restore protected filesystem paths
+  m = restorePaths(m, savedPaths);
 
   // Layer 3: Tool name fingerprint bypass (quoted replacement for precision)
   for (const [orig, cc] of config.toolRenames) {


### PR DESCRIPTION
## Summary

- Layer 2 `split/join` replacements now extract filesystem paths into NUL-delimited
  placeholders before applying replacements, then restore them afterward.
- Paths with 2+ segments (e.g. `/home/user/.openclaw/media/...`, `./src/openclaw/mod.js`)
  are matched by a regex with negative lookbehind `(?<![\/:])` to skip URL schemes.
- Response-side `reverseMap()` is unchanged — its replacements are corrective (restoring
  replaced strings back to originals), so path protection is not needed there.

**Root cause:** `processBody()` did `m.split(find).join(replace)` on the entire request
body, including filesystem paths inside tool call arguments. With any config that replaces
`openclaw` (e.g. → `tataclaw`, `ocplatform`), paths like `/home/user/.openclaw/media/...`
get corrupted. OpenClaw's `assertLocalMediaAllowed()` then rejects the path because it's
no longer under an allowed directory root.

**Likely related:** #29 — reports intermittent ENOENT on files under `~/.openclaw/` that
`ls` confirms exist. All affected paths (`openclaw.json`, `extensions/lossless-claw/...`,
`openclaw.plugin.json`) contain `openclaw` and would be corrupted by Layer 2. The symptom
(`ls` works but `open()`/`read()` returns ENOENT) matches exactly: `ls` sees the real path,
but the tool call uses the corrupted path which doesn't exist on disk.

## Test plan

- [x] Regex correctly matches filesystem paths (`/home/...`, `./src/...`, `../config/...`)
- [x] Regex skips URL schemes (`https://...`, `http://...`, `file:///...`)
- [x] Regex does not match standalone words or single-segment paths
- [x] E2E: filesystem paths preserved while brand text in prose is still replaced
- [x] `node -c proxy.js` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)