### PR TITLE
fix(non-sse): forward upstream keep-alive heartbeats to prevent clien…

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -913,20 +913,62 @@ function startServer(config) {
             res.end();
           });
         } else {
+          // Non-SSE (JSON) response. Some upstream proxies (e.g. CLIProxyAPI
+          // with nonstream-keepalive-interval) inject blank-line heartbeat
+          // bytes into the response stream every N seconds during long-running
+          // inference so that clients don't time out their idle/heartbeat
+          // timer. The previous implementation buffered the entire response
+          // and only flushed at upRes.on('end'), silently absorbing those
+          // heartbeat bytes — clients with a < N-second heartbeat timer (e.g.
+          // OpenClaw at 15s) saw no traffic for the full inference duration
+          // and disconnected.
+          //
+          // Fix: forward any leading ASCII whitespace bytes to the client
+          // immediately as they arrive. Once a non-whitespace byte appears,
+          // the actual JSON body has begun, so switch to the buffer-and-
+          // transform path so reverseMap + thinking-block masking can run on
+          // the complete body. Content-Length is removed because the final
+          // size is unknown when headers are written; Node falls back to
+          // Transfer-Encoding: chunked automatically.
+          let seenRealContent = false;
+          let headersWritten = false;
           const respChunks = [];
-          upRes.on('data', c => respChunks.push(c));
+          const ensureHeaders = () => {
+            if (headersWritten) return;
+            const nh = { ...upRes.headers };
+            delete nh['content-length'];
+            delete nh['transfer-encoding'];
+            try { res.writeHead(status, nh); headersWritten = true; } catch (e) {}
+          };
+          upRes.on('data', c => {
+            if (!seenRealContent) {
+              let i = 0;
+              while (i < c.length) {
+                const b = c[i];
+                if (b === 0x20 || b === 0x09 || b === 0x0a || b === 0x0d) { i++; }
+                else { break; }
+              }
+              if (i > 0) {
+                ensureHeaders();
+                try { res.write(c.subarray(0, i)); } catch (e) {}
+              }
+              if (i < c.length) {
+                seenRealContent = true;
+                respChunks.push(c.subarray(i));
+              }
+            } else {
+              respChunks.push(c);
+            }
+          });
           upRes.on('end', () => {
+            ensureHeaders();
             let respBody = Buffer.concat(respChunks).toString();
             // Mask thinking blocks so reverseMap can't mutate them. The client
             // stores these bytes and echoes them on the next turn; Anthropic
             // enforces byte-equality on the latest assistant message.
             const { masked: rMasked, masks: rMasks } = maskThinkingBlocks(respBody);
             respBody = unmaskThinkingBlocks(reverseMap(rMasked, config), rMasks);
-            const nh = { ...upRes.headers };
-            delete nh['transfer-encoding']; // avoid conflict with content-length
-            nh['content-length'] = Buffer.byteLength(respBody);
-            res.writeHead(status, nh);
-            res.end(respBody);
+            try { res.write(respBody); res.end(); } catch (e) {}
           });
         }
       });


### PR DESCRIPTION
…t timeouts

When proxying non-streaming JSON responses, the previous implementation collected the entire upstream response into respChunks and only flushed at upRes.on('end'). Upstream proxies that inject periodic keep-alive bytes during long-running inference (e.g. CLIProxyAPI's nonstream-keepalive-interval, which writes blank lines every 15s) had those heartbeat bytes silently absorbed into the buffer instead of forwarded to the client.

OpenClaw and other clients with a 15-second heartbeat/idle timeout saw no bytes for the full duration of any inference taking longer than 15s and disconnected with a timeout error, even though the upstream proxy was actively keeping the connection alive.

Reproduction
------------
With openclaw-billing-proxy chained between a client and CLIProxyAPI:

  curl -sk -o /dev/null \
    -w 'starttransfer=%{time_starttransfer}s total=%{time_total}s\n' \
    -X POST 'https://billing-proxy/v1/messages' \
    -d '{"model":"claude-opus-4-6","max_tokens":2000,
         "messages":[{"role":"user","content":"<long prompt>"}]}'

  Before fix:
    starttransfer=53.394694s total=53.394694s
    ^^ first byte and last byte arrive together — clients with heartbeat
       timeouts shorter than the full inference duration disconnect

  After fix:
    starttransfer=15.012796s total=53.394694s
    ^^ first byte arrives at exactly the upstream's keep-alive interval;
       client receives a heartbeat byte before its timeout fires

Fix
---
Forward leading ASCII whitespace bytes (0x20/0x09/0x0a/0x0d, which is what nonstream keep-alive padding uses) to the client immediately as they arrive. Once a non-whitespace byte appears the JSON body has begun, so switch to the existing buffer-and-transform path. The reverseMap + thinking-block masking semantics on the JSON body are unchanged.

Since chunks may now be written across two res.write() calls (whitespace prefix + final body), Content-Length is removed and Transfer-Encoding: chunked is used (Node sets this automatically).

Verified
--------
- Long non-streaming request (>15s): starttransfer drops from ~total to exactly the upstream keep-alive interval
- Short non-streaming request (<15s): no behavior change (no whitespace prefix arrives, falls through to end-of-response write, identical to pre-fix behavior)
- SSE streaming request: no behavior change (different code path)
- Response body integrity: final JSON arrives intact, reverseMap and thinking-mask still applied as before