### PR TITLE
best-effort token auto-refresh on expired token

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -811,10 +811,10 @@ function startServer(config) {
       // On failure, fall through — the original getToken() below handles everything.
       try {
         const pre = getToken(config.credsPath);
-        if (isFinite(pre.expiresAt) && pre.expiresAt - Date.now() < 0) {
+        if (isFinite(pre.expiresAt) && pre.expiresAt - Date.now() < 60000) {
           await refreshOAuthToken();
         }
-      } catch (_) {}
+      } catch (e) { console.log('[token] refresh failed:', e.message); }
       let body = Buffer.concat(chunks);
       let oauth;
       try { oauth = getToken(config.credsPath); } catch (e) {

--- a/proxy.js
+++ b/proxy.js
@@ -433,6 +433,34 @@ function getToken(credsPath) {
   return oauth;
 }
 
+// ─── Token Refresh ─────────────────────────────────────────────────────────
+// Best-effort auto-refresh: when a request arrives and the token is already
+// expired, invoke the host's Claude CLI to refresh it. Claude CLI internally
+// uses the refresh_token to obtain a new access_token and writes it back to
+// ~/.claude/.credentials.json. The proxy then re-reads the file.
+//
+// This is a convenience helper only — if it fails, the request proceeds with
+// the expired token and the API will return 401, same as without this code.
+//
+// refreshInProgress deduplicates concurrent calls so only one CLI invocation
+// runs at a time; subsequent requests await the same Promise.
+let refreshInProgress = null;
+
+function refreshOAuthToken() {
+  if (refreshInProgress) return refreshInProgress;
+  refreshInProgress = new Promise((resolve, reject) => {
+    const { execFile } = require('child_process');
+    console.log('[token] Token expired, running claude CLI to refresh...');
+    execFile('claude', ['-p', 'ping', '--max-turns', '1', '--no-session-persistence'], { timeout: 30000, env: { ...process.env, PATH: process.env.PATH + ':/home/ubuntu/.local/bin' } }, (err) => {
+      refreshInProgress = null;
+      if (err) { reject(new Error(`claude refresh failed: ${err.message}`)); return; }
+      console.log('[token] CLI refresh done');
+      resolve();
+    });
+  });
+  return refreshInProgress;
+}
+
 // ─── Helper ─────────────────────────────────────────────────────────────────
 // String-aware bracket matching: skips [/] inside JSON string values so that
 // brackets in tool descriptions or text content don't corrupt the depth count.
@@ -778,7 +806,15 @@ function startServer(config) {
     const chunks = [];
 
     req.on('data', c => chunks.push(c));
-    req.on('end', () => {
+    req.on('end', async () => {
+      // Best-effort token refresh: if expired, try CLI refresh before proceeding.
+      // On failure, fall through — the original getToken() below handles everything.
+      try {
+        const pre = getToken(config.credsPath);
+        if (isFinite(pre.expiresAt) && pre.expiresAt - Date.now() < 0) {
+          await refreshOAuthToken();
+        }
+      } catch (_) {}
       let body = Buffer.concat(chunks);
       let oauth;
       try { oauth = getToken(config.credsPath); } catch (e) {

--- a/proxy.js
+++ b/proxy.js
@@ -446,14 +446,37 @@ function getToken(credsPath) {
 // runs at a time; subsequent requests await the same Promise.
 let refreshInProgress = null;
 
+// Find claude CLI: 1. config.json "claudeBin"  2. PATH  3. ~/.local/bin/claude
+function findClaudeBin() {
+  try {
+    const cfg = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+    if (cfg.claudeBin && fs.existsSync(cfg.claudeBin)) return cfg.claudeBin;
+  } catch (_) {}
+  try {
+    return require('child_process').execSync('command -v claude 2>/dev/null', { encoding: 'utf8' }).trim();
+  } catch (_) {}
+  const guess = path.join(os.homedir(), '.local', 'bin', 'claude');
+  if (fs.existsSync(guess)) return guess;
+  return null;
+}
+
 function refreshOAuthToken() {
   if (refreshInProgress) return refreshInProgress;
+  const bin = findClaudeBin();
+  if (!bin) {
+    console.log('[token] Token expired but claude CLI not found, skipping refresh (set "claudeBin" in config.json)');
+    return Promise.resolve();
+  }
   refreshInProgress = new Promise((resolve, reject) => {
     const { execFile } = require('child_process');
     console.log('[token] Token expired, running claude CLI to refresh...');
-    execFile('claude', ['-p', 'ping', '--max-turns', '1', '--no-session-persistence'], { timeout: 30000, env: { ...process.env, PATH: process.env.PATH + ':/home/ubuntu/.local/bin' } }, (err) => {
+    execFile(bin, ['-p', 'ping', '--max-turns', '1', '--no-session-persistence'], { timeout: 30000 }, (err) => {
       refreshInProgress = null;
-      if (err) { reject(new Error(`claude refresh failed: ${err.message}`)); return; }
+      if (err) {
+        console.log('[token] refresh failed:', err.message);
+        reject(err);
+        return;
+      }
       console.log('[token] CLI refresh done');
       resolve();
     });
@@ -814,7 +837,7 @@ function startServer(config) {
         if (isFinite(pre.expiresAt) && pre.expiresAt - Date.now() < 60000) {
           await refreshOAuthToken();
         }
-      } catch (e) { console.log('[token] refresh failed:', e.message); }
+      } catch (_) {}
       let body = Buffer.concat(chunks);
       let oauth;
       try { oauth = getToken(config.credsPath); } catch (e) {


### PR DESCRIPTION
## Summary

When a request arrives and the OAuth token is expiring (<60s remaining),
the proxy runs `claude -p "ping" --max-turns 1 --no-session-persistence`
to refresh the token before forwarding.

Best-effort only — if refresh fails, the request proceeds as if this
code did not exist. Triggered on-demand, not by cron or polling.

## Why 60 seconds?

Claude CLI only rotates the token when <2 minutes remain
([confirmed by @DBostik in #32](https://github.com/zacdcook/openclaw-billing-proxy/pull/32#issuecomment-4228081149)).
60 seconds sits inside this window with enough buffer for the ~8s CLI invocation.

## Design decisions

- **On-demand, not polling** — no timers, no cron, no background threads.
  Refresh only happens when a real request needs it.
- **Best-effort** — wrapped in try/catch. Failure is logged and swallowed;
  the original `getToken()` flow is untouched.
- **Deduplication** — `refreshInProgress` ensures concurrent requests share
  a single CLI invocation instead of spawning many.
- **CLI-based refresh** — delegates to `claude -p "ping"` rather than
  calling the OAuth endpoint directly. The CLI already handles token
  refresh reliably, so reusing it avoids breakage if Anthropic changes
  the OAuth flow in the future.
- **Minimal diff** — ~30 lines added, 1 line changed (`() =>` → `async () =>`).
  Original request handling logic is not modified.

## Verified in production

Proxy ran for ~7 hours, served 78 requests. Token expired naturally,
auto-refreshed in 8 seconds, and continued serving — zero downtime:

```
Apr 14 03:31:09 claude-proxy node[561265]:   Token expires:     6.8h
Apr 14 03:36:34 claude-proxy node[561265]: [03:36:34] #1 POST /v1/messages (173b -> 456b)
Apr 14 03:36:38 claude-proxy node[561265]: [03:36:34] #1 > 200
   ...
Apr 14 10:03:05 claude-proxy node[561265]: [10:03:05] #78 POST /v1/messages (69766b -> 54141b)
Apr 14 10:03:07 claude-proxy node[561265]: [10:03:05] #78 > 200
Apr 14 10:30:09 claude-proxy node[561265]: [token] Token expired, running claude CLI to refresh...
Apr 14 10:30:17 claude-proxy node[561265]: [token] CLI refresh done
Apr 14 10:30:17 claude-proxy node[561265]: [10:30:17] #79 POST /v1/messages (69632b -> 50029b)
Apr 14 10:30:19 claude-proxy node[561265]: [10:30:17] #79 > 200
Apr 14 10:30:21 claude-proxy node[561265]: [10:30:21] #80 POST /v1/messages (83628b -> 65149b)
Apr 14 10:30:23 claude-proxy node[561265]: [10:30:21] #80 > 200
Apr 14 10:30:31 claude-proxy node[561265]: [10:30:31] #81 POST /v1/messages (84308b -> 66123b)
Apr 14 10:30:33 claude-proxy node[561265]: [10:30:31] #81 > 200
Apr 14 10:45:09 claude-proxy node[561265]: [10:45:09] #83 POST /v1/messages (69735b -> 49879b)
Apr 14 10:45:11 claude-proxy node[561265]: [10:45:09] #83 > 200
```

## Limitations

- Requires `claude` CLI available on PATH. Only tested with systemd deployment, not Docker.
- The triggering request is delayed by ~8s while the CLI runs.

Relates to #6, #39