### PR TITLE
fix: reconstruct reverse-mapped tokens split across SSE delta events

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -738,6 +738,142 @@ function reverseMap(text, config) {
   return r;
 }
 
+function createSseEventTransformer(config) {
+  let currentBlockIsThinking = false;
+  const streamState = new Map(); // key "index:field" -> raw, un-emitted buffer
+
+  // Every literal string reverseMap() searches for. reverseMap() rewrites tool
+  // and property names in BOTH plain ("Name") and JSON-escaped (\"Name\") form,
+  // so both variants are patterns whose prefix could appear at a buffer tail.
+  const patterns = [];
+  for (const [, cc] of config.toolRenames) {
+    patterns.push('"' + cc + '"', '\\"' + cc + '\\"');
+  }
+  for (const [, renamed] of config.propRenames) {
+    patterns.push('"' + renamed + '"', '\\"' + renamed + '\\"');
+  }
+  for (const [sanitized] of config.reverseMap) {
+    patterns.push(sanitized);
+  }
+  const maxPatternLen = patterns.reduce((m, p) => Math.max(m, p.length), 1);
+
+  // Streaming reverse-map. reverseMap() only rewrites COMPLETE patterns, so a
+  // pattern split across SSE delta events (".ocpla" then "tform") would be
+  // emitted raw before it completes and could never be retracted. Hold back
+  // the trailing raw bytes that might still grow into a pattern, emit only the
+  // safe prefix, and carry the rest to the next delta (or the stop flush).
+  function streamReverse(key, value, isFinal) {
+    const buf = (streamState.get(key) || '') + value;
+    let cut;
+    if (isFinal) {
+      cut = buf.length;
+    } else {
+      // A pattern is at most maxPatternLen long, so anything before this point
+      // cannot be the start of a still-incomplete pattern.
+      cut = Math.max(0, buf.length - (maxPatternLen - 1));
+      // ...but a *complete* occurrence may straddle that point. Pull the cut
+      // back to its start so the whole occurrence stays in the carry buffer.
+      let moved = true;
+      while (moved) {
+        moved = false;
+        for (const p of patterns) {
+          let idx = buf.indexOf(p);
+          while (idx !== -1 && idx < cut) {
+            if (idx + p.length > cut) { cut = idx; moved = true; }
+            idx = buf.indexOf(p, idx + 1);
+          }
+        }
+      }
+    }
+    const carry = buf.slice(cut);
+    if (carry) streamState.set(key, carry); else streamState.delete(key);
+    return reverseMap(buf.slice(0, cut), config);
+  }
+
+  function buildDeltaEvent(index, field, value) {
+    const delta = field === 'partial_json'
+      ? { type: 'input_json_delta', partial_json: value }
+      : { type: 'text_delta', text: value };
+    return 'event: content_block_delta\ndata: ' +
+      JSON.stringify({ type: 'content_block_delta', index, delta }) + '\n\n';
+  }
+
+  // Emit whatever is still held for a block as synthetic delta event(s).
+  // Called on content_block_stop (and flushAll) — the block has no more deltas,
+  // so the held tail must come out now or it is lost.
+  function flushBlock(index) {
+    let out = '';
+    for (const field of ['text', 'partial_json']) {
+      const key = index + ':' + field;
+      if (!streamState.has(key)) continue;
+      const rest = streamReverse(key, '', true);
+      if (rest) out += buildDeltaEvent(index, field, rest);
+    }
+    return out;
+  }
+
+  const transform = (event) => {
+    let dataIdx = event.startsWith('data: ') ? 0 : event.indexOf('\ndata: ');
+    if (dataIdx === -1) return reverseMap(event, config);
+    if (dataIdx > 0) dataIdx += 1;
+    const dataLineEnd = event.indexOf('\n', dataIdx + 6);
+    const dataStr = dataLineEnd === -1
+      ? event.slice(dataIdx + 6)
+      : event.slice(dataIdx + 6, dataLineEnd);
+
+    let payload;
+    try {
+      payload = JSON.parse(dataStr);
+    } catch (_) {
+      return reverseMap(event, config);
+    }
+
+    if (payload.type === 'content_block_start') {
+      const t = payload.content_block && payload.content_block.type;
+      if (t === 'thinking' || t === 'redacted_thinking') {
+        currentBlockIsThinking = true;
+        return event;
+      }
+      currentBlockIsThinking = false;
+      return reverseMap(event, config);
+    }
+    if (payload.type === 'content_block_stop') {
+      const wasThinking = currentBlockIsThinking;
+      currentBlockIsThinking = false;
+      if (wasThinking) return event;
+      const flushed = typeof payload.index === 'number' ? flushBlock(payload.index) : '';
+      return flushed + reverseMap(event, config);
+    }
+    if (currentBlockIsThinking) return event;
+
+    if (payload.type === 'content_block_delta' && payload.delta && typeof payload.index === 'number') {
+      if (payload.delta.type === 'input_json_delta' && typeof payload.delta.partial_json === 'string') {
+        payload.delta.partial_json = streamReverse(payload.index + ':partial_json', payload.delta.partial_json, false);
+      } else if (payload.delta.type === 'text_delta' && typeof payload.delta.text === 'string') {
+        payload.delta.text = streamReverse(payload.index + ':text', payload.delta.text, false);
+      } else {
+        return reverseMap(event, config);
+      }
+      const rewritten = JSON.stringify(payload);
+      return event.slice(0, dataIdx + 6) + rewritten + (dataLineEnd === -1 ? '' : event.slice(dataLineEnd));
+    }
+
+    return reverseMap(event, config);
+  };
+
+  // Flush any buffer left when the stream ends without a content_block_stop
+  // (malformed stream). Well-formed streams flush per block on stop.
+  transform.flushAll = () => {
+    let out = '';
+    const indices = new Set();
+    for (const key of streamState.keys()) indices.add(Number(key.slice(0, key.indexOf(':'))));
+    for (const index of indices) out += flushBlock(index);
+    return out;
+  };
+
+  return transform;
+}
+
 // ─── Server ─────────────────────────────────────────────────────────────────
 function startServer(config) {
   let requestCount = 0;
@@ -861,38 +997,7 @@ function startServer(config) {
           // don't decode as U+FFFD.
           const decoder = new StringDecoder('utf8');
           let pending = '';
-          let currentBlockIsThinking = false;
-
-          const transformEvent = (event) => {
-            // Locate the data: line (always at the start of an SSE line)
-            let dataIdx = event.startsWith('data: ') ? 0 : event.indexOf('\ndata: ');
-            if (dataIdx === -1) return reverseMap(event, config);
-            if (dataIdx > 0) dataIdx += 1; // skip the leading \n
-            const dataLineEnd = event.indexOf('\n', dataIdx + 6);
-            const dataStr = dataLineEnd === -1
-              ? event.slice(dataIdx + 6)
-              : event.slice(dataIdx + 6, dataLineEnd);
-
-            if (dataStr.indexOf('"type":"content_block_start"') !== -1) {
-              if (dataStr.indexOf('"content_block":{"type":"thinking"') !== -1 ||
-                  dataStr.indexOf('"content_block":{"type":"redacted_thinking"') !== -1) {
-                currentBlockIsThinking = true;
-                return event; // pass through unchanged
-              }
-              currentBlockIsThinking = false;
-              return reverseMap(event, config);
-            }
-            if (dataStr.indexOf('"type":"content_block_stop"') !== -1) {
-              const wasThinking = currentBlockIsThinking;
-              currentBlockIsThinking = false;
-              return wasThinking ? event : reverseMap(event, config);
-            }
-            if (currentBlockIsThinking) {
-              // thinking_delta / signature_delta / etc. inside a thinking block
-              return event;
-            }
-            return reverseMap(event, config);
-          };
+          const transformEvent = createSseEventTransformer(config);
 
           upRes.on('data', (chunk) => {
             pending += decoder.write(chunk);
@@ -910,6 +1015,8 @@ function startServer(config) {
               // well-formed SSE, but flush to avoid silent drops.
               res.write(transformEvent(pending));
             }
+            // Flush any buffer held for a block that never got a stop event.
+            res.write(transformEvent.flushAll());
             res.end();
           });
         } else {
@@ -974,6 +1081,31 @@ function startServer(config) {
   process.on('SIGTERM', () => process.exit(0));
 }
 
+function applySseReverseMapChunks(chunks, config) {
+  const decoder = new StringDecoder('utf8');
+  let pending = '';
+  let out = '';
+  const transformEvent = createSseEventTransformer(config);
+
+  for (const chunk of chunks) {
+    pending += decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8'));
+    let sepIdx;
+    while ((sepIdx = pending.indexOf('\n\n')) !== -1) {
+      const event = pending.slice(0, sepIdx + 2);
+      pending = pending.slice(sepIdx + 2);
+      out += transformEvent(event);
+    }
+  }
+  pending += decoder.end();
+  if (pending.length > 0) out += transformEvent(pending);
+  out += transformEvent.flushAll();
+  return out;
+}
+
+module.exports = { loadConfig, reverseMap, applySseReverseMapChunks };
+
 // ─── Main ───────────────────────────────────────────────────────────────────
-const config = loadConfig();
-startServer(config);
+if (require.main === module) {
+  const config = loadConfig();
+  startServer(config);
+}

--- a/test/sse-reversemap.test.js
+++ b/test/sse-reversemap.test.js
@@ -1,0 +1,95 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { reverseMap, applySseReverseMapChunks } = require('../proxy.js');
+
+// Deterministic config — independent of the host's config.json.
+const CONFIG = {
+  reverseMap: [
+    ['ocplatform', 'openclaw'],
+    ['routing-layer', 'billing-proxy'],
+  ],
+  toolRenames: [['message', 'SendMessage']],
+  propRenames: [['path', 'file_path']],
+};
+
+function textEvent(index, text) {
+  return 'event: content_block_delta\ndata: ' +
+    JSON.stringify({ type: 'content_block_delta', index, delta: { type: 'text_delta', text } }) + '\n\n';
+}
+function jsonEvent(index, partial) {
+  return 'event: content_block_delta\ndata: ' +
+    JSON.stringify({ type: 'content_block_delta', index, delta: { type: 'input_json_delta', partial_json: partial } }) + '\n\n';
+}
+function stopEvent(index) {
+  return 'data: ' + JSON.stringify({ type: 'content_block_stop', index }) + '\n\n';
+}
+
+// Reassemble the text_delta / input_json_delta payloads from transformer output.
+function reconstruct(out, field) {
+  return out.split('\n\n').map((e) => e.trim()).filter(Boolean)
+    .map((e) => e.split('\n').find((l) => l.startsWith('data: ')))
+    .filter(Boolean)
+    .map((l) => JSON.parse(l.slice(6)))
+    .filter((p) => p.type === 'content_block_delta' && p.delta &&
+      (p.delta.type === 'text_delta' || p.delta.type === 'input_json_delta'))
+    .map((p) => (field in p.delta ? p.delta[field] : ''))
+    .join('');
+}
+
+test('text_delta: exact reconstruction at every two-way split offset', () => {
+  const full = 'open ~/.ocplatform inside the routing-layer please';
+  const expected = reverseMap(full, CONFIG);
+  for (let i = 1; i < full.length; i++) {
+    const events = [textEvent(0, full.slice(0, i)), textEvent(0, full.slice(i)), stopEvent(0)];
+    const got = reconstruct(applySseReverseMapChunks(events, CONFIG), 'text');
+    assert.equal(got, expected, `split at offset ${i}`);
+  }
+});
+
+test('text_delta: exact reconstruction when split into single characters', () => {
+  const full = 'cd ocplatform/routing-layer/run';
+  const expected = reverseMap(full, CONFIG);
+  const events = full.split('').map((ch) => textEvent(0, ch));
+  events.push(stopEvent(0));
+  const got = reconstruct(applySseReverseMapChunks(events, CONFIG), 'text');
+  assert.equal(got, expected);
+});
+
+test('input_json_delta: exact reconstruction at every two-way split offset', () => {
+  // partial_json carries tool args; inner quotes arrive JSON-escaped.
+  const full = '{\\"path\\":\\"~/.ocplatform/ws\\",\\"SendMessage\\":\\"hi\\"}';
+  const expected = reverseMap(full, CONFIG);
+  for (let i = 1; i < full.length; i++) {
+    const events = [jsonEvent(1, full.slice(0, i)), jsonEvent(1, full.slice(i)), stopEvent(1)];
+    const got = reconstruct(applySseReverseMapChunks(events, CONFIG), 'partial_json');
+    assert.equal(got, expected, `split at offset ${i}`);
+  }
+});
+
+test('split token across raw TCP chunks within one SSE event', () => {
+  const event = textEvent(0, 'cd ~/.ocplatform/workspace') + stopEvent(0);
+  const splitPoint = event.indexOf('ocplatform') + 'ocpla'.length;
+  const chunks = [event.slice(0, splitPoint), event.slice(splitPoint)];
+  const got = reconstruct(applySseReverseMapChunks(chunks, CONFIG), 'text');
+  assert.equal(got, 'cd ~/.openclaw/workspace');
+});
+
+test('flushAll emits the held tail when no content_block_stop arrives', () => {
+  // Token split across events, stream ends abruptly without a stop event.
+  const events = [textEvent(0, 'go to ~/.ocpla'), textEvent(0, 'tform/ws')];
+  const got = reconstruct(applySseReverseMapChunks(events, CONFIG), 'text');
+  assert.equal(got, 'go to ~/.openclaw/ws');
+});
+
+test('thinking and redacted_thinking blocks pass through byte-identical', () => {
+  const events = [
+    'data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}\n\n',
+    'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"raw ocplatform routing-layer"}}\n\n',
+    'data: {"type":"content_block_stop","index":0}\n\n',
+    'data: {"type":"content_block_start","index":1,"content_block":{"type":"redacted_thinking"}}\n\n',
+    'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ocplatform"}}\n\n',
+    'data: {"type":"content_block_stop","index":1}\n\n',
+  ];
+  const out = applySseReverseMapChunks(events, CONFIG);
+  assert.equal(out, events.join(''));
+});


### PR DESCRIPTION
Fixes #55.

## Problem

`reverseMap()` only rewrites **complete** patterns. The streaming SSE response transformer applied it independently per `content_block_delta` event, so a sanitized identifier split across two delta events (`.ocpla` then `tform`) was never reverse-mapped and the sanitized form leaked to the client.

A naive slice-offset attempt makes it worse: it emits the incomplete prefix raw, then when the next event completes the pattern the already-sent bytes cannot be retracted, producing **mangled** output like `.ocplalaw`.

## Fix

`createSseEventTransformer()` does a proper streaming replace:

- **`streamReverse()`** keeps a raw, un-emitted buffer per content block + field. Each delta holds back the trailing bytes that could still grow into a pattern (`maxPatternLen-1`), emits only the safe prefix, and pulls the cut back so no *complete* occurrence straddles it.
- The held tail is flushed as synthetic `content_block_delta` events on **`content_block_stop`**; **`flushAll()`** covers streams that end without a stop.
- `thinking` / `redacted_thinking` blocks stay byte-identical pass-throughs.
- Exports `loadConfig` / `reverseMap` / `applySseReverseMapChunks` and guards `startServer()` behind `require.main` for unit-testing.

## Tests

`test/sse-reversemap.test.js` (`node --test`, no new deps) asserts **exact reconstruction** — `reconstruct(transform(events)) === reverseMap(wholeInput)` — at:

- every two-way split offset of a `text_delta`
- single-character splitting of a `text_delta`
- every two-way split offset of an `input_json_delta` (escaped tool/prop names)
- a token split across raw TCP chunks
- `flushAll` when no `content_block_stop` arrives
- `thinking` / `redacted_thinking` byte-invariance

All pass.