### PR TITLE
docs: honest upstream fork notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OpenClaw Subscription Billing Proxy
 
+`openclaw-billing-proxy · fork of zacdcook/openclaw-billing-proxy · jediswimmer`
+
+> [!NOTE]
+> jediswimmer fork of [zacdcook/openclaw-billing-proxy](https://github.com/zacdcook/openclaw-billing-proxy). Default branch is `master`. This clone is behind upstream. Not a Titans Rift product. Follow upstream for install.
+
 Route your OpenClaw API requests through your Claude Max/Pro subscription instead of Extra Usage billing.
 
 ## What This Does


### PR DESCRIPTION
## Summary

Fork-class README pass for `jediswimmer/openclaw-billing-proxy`. Honest upstream. No Titans Rift product claim. No banner seam.

Base: `master`. Draft only. House card t_42c6dd2c. No merge.
